### PR TITLE
"Bump nanoid from 3.3.7 to 3.3.8 in the npm_and_yarn group"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@next/third-parties": "^15.0.3",
         "@vercel/analytics": "^1.4.1",
         "@vercel/speed-insights": "^1.0.12",
-        "cross-spawn": ">=7.0.5",
         "eslint": "7.32.0",
         "handlebars": "^4.7.8",
         "next": "^15.0.3",
@@ -26,19 +25,20 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
         "react-imported-component": "^6.5.4",
-        "webpack": "^5.94.0"
+        "webpack": "^5.94.0",
+        "cross-spawn": ">=7.0.5"
       },
       "devDependencies": {
         "@types/gtag.js": "^0.0.20",
         "@types/node": "18.11.17",
         "@types/react": "17.0.30",
         "autoprefixer": "^10.3.7",
-        "cross-spawn": ">=7.0.5",
         "eslint": "7.32.0",
         "eslint-config-next": "^13.0.7",
         "postcss": ">=8.4.35",
         "tailwindcss": "^2.2.17",
-        "typescript": "4.5.2"
+        "typescript": "4.5.2",
+        "cross-spawn": ">=7.0.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4030,9 +4030,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -11501,9 +11501,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",


### PR DESCRIPTION
lisagorewitdecker/estopdrvngschl-nextjs#656