### PR TITLE
Fix: Hand-editing `tar` requirement strings inside the bundled `npm` …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5881,7 +5881,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^14.0.0",
         "supports-color": "^10.2.2",
-        "tar": ">=7.5.21",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -6679,7 +6679,7 @@
         "minimatch": "^10.0.3",
         "npm-package-arg": "^14.0.0",
         "pacote": "^22.0.0",
-        "tar": ">=7.5.21"
+        "tar": "^7.5.1"
       },
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
@@ -6971,7 +6971,7 @@
         "nopt": "^10.0.0",
         "proc-log": "^7.0.0",
         "semver": "^7.3.5",
-        "tar": ">=7.5.21",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
         "undici": "^6.25.0",
         "which": "^7.0.0"
@@ -7146,7 +7146,7 @@
         "proc-log": "^7.0.0",
         "sigstore": "^5.0.0",
         "ssri": "^14.0.0",
-        "tar": ">=7.5.21"
+        "tar": "^7.4.3"
       },
       "bin": {
         "pacote": "bin/index.js"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "nth-check": "^2.0.1",
     "postcss": "^8.5.10",
     "underscore": "^1.13.8",
-    "@tootallnate/once": "^2.0.1"
+    "@tootallnate/once": "^2.0.1",
+    "tar": ">=7.5.21"
   }
 }


### PR DESCRIPTION
…package entries in package-lock.json is ineffective and leaves the lockfile inconsistent with what npm regenerates.

This commit fixes the issue reported at package-lock.json:7403

## The bug

The PR edits four `dependencies.tar` requirement strings to `>=7.5.21` inside **bundled** `npm` package entries of `package-lock.json`:

| Line | Package | Committed (edited) | Real bundled metadata | |------|---------|--------------------|-----------------------| | 5884 | `node_modules/npm` | `>=7.5.21` | `^7.5.19` | | 6682 | `node_modules/npm/node_modules/libnpmdiff` | `>=7.5.21` | `^7.5.1` | | 6974 | `node_modules/npm/node_modules/node-gyp` | `>=7.5.21` | `^7.5.4` | | 7149 | `node_modules/npm/node_modules/pacote` | `>=7.5.21` | `^7.4.3` |

`tar` is listed in npm@12.0.2's `bundleDependencies` (lockfile line 5806) and ships physically inside the npm tarball — `node_modules/npm/node_modules/tar` (line 7403) has `"inBundle": true` and `"version": "7.5.19"`.

### Why it's ineffective and inconsistent

I verified in the sandbox:

- **The installed tar version does not change.** After a clean `rm -rf node_modules && npm install`, `node_modules/npm/node_modules/tar/package.json` stayed at `7.5.19` (< 7.5.21). Editing requirement strings in the lockfile cannot alter the version that ships bundled inside the npm tarball.
- **npm reverts the edits.** Running `npm install` reconciles the bundled sub-package requirement strings back to the values read from the installed npm package's own metadata (`^7.5.19`, `^7.5.1`, `^7.5.4`, `^7.4.3`), leaving the committed lockfile immediately out of sync with a fresh regeneration.

Net effect: the intended security upgrade is **not** applied, and the lockfile is left in an inconsistent state that any `npm install`/`npm ci` will churn.

### The override doesn't work either (key finding)

I also empirically tested the "add `tar` to `overrides`" approach with a clean install: the override did **not** change the bundled tar version (still 7.5.19) and was not even recorded in the regenerated lockfile, because npm does not apply `overrides` to a package's own **bundled** dependencies. See notes — the only genuine remediation is upgrading the `npm` dependency to a build that bundles tar >= 7.5.21 (or dropping `npm` as a runtime dependency).

## The fix

1. **package-lock.json** — reverted the four hand-edited requirement strings back to the values that match the actual installed bundled metadata, eliminating the lockfile inconsistency:
   - line 5884 → `^7.5.19`
   - line 6682 → `^7.5.1`
   - line 6974 → `^7.5.4`
   - line 7149 → `^7.4.3`

   These are exactly the values `npm install` regenerates, so the lockfile is now stable/idempotent. JSON validity was verified.

2. **package.json** — added `"tar": ">=7.5.21"` to the existing `overrides` block, following the repo's established pattern for declaring the desired transitive version.

I kept the fix to a minimal 4-line lockfile change (avoiding the ~1000-line churn a full regeneration produces) plus the single override line. Note the override alone is not sufficient for the bundled copy — a full remediation requires upgrading `npm` (documented in notes).